### PR TITLE
Feature/metrics

### DIFF
--- a/cmd/gitcollector/subcmd/download.go
+++ b/cmd/gitcollector/subcmd/download.go
@@ -10,6 +10,7 @@ import (
 	"github.com/src-d/gitcollector/discovery"
 	"github.com/src-d/gitcollector/downloader"
 	"github.com/src-d/gitcollector/library"
+	"github.com/src-d/gitcollector/metrics"
 	"github.com/src-d/go-borges/siva"
 	"gopkg.in/src-d/go-billy.v4/osfs"
 	"gopkg.in/src-d/go-cli.v0"
@@ -26,6 +27,8 @@ type DownloadCmd struct {
 	NotAllowUpdates bool   `long:"no-updates" description:"don't allow updates on already downloaded repositories" env:"GITCOLLECTOR_NO_UPDATES"`
 	Org             string `long:"org" env:"GITHUB_ORGANIZATION" description:"github organization" required:"true"`
 	Token           string `long:"token" env:"GITHUB_TOKEN" description:"github token"`
+	MetricsDBURI    string `long:"metrics-db" env:"GITCOLLECTOR_METRICS_DB_URI" description:"uri to a database where metrics will be sent"`
+	MetricsDBTable  string `long:"metrics-db-table" env:"GITCOLLECTOR_METRICS_DB_TABLE" default:"gitcollector_metrics" description:"table name where the metrics will be added"`
 }
 
 // Execute runs the command.
@@ -93,7 +96,20 @@ func (c *DownloadCmd) Execute(args []string) error {
 		&gitcollector.JobSchedulerOpts{},
 	)
 
-	wp := gitcollector.NewWorkerPool(jobScheduler, nil)
+	var mc *metrics.Collector
+	if c.MetricsDBURI != "" {
+		db, err := metrics.PrepareDB(
+			c.MetricsDBURI, c.MetricsDBTable, c.Org,
+		)
+		check(err, "metrics database")
+
+		mc = metrics.NewCollector(&metrics.CollectorOpts{
+			Log:  log.New(nil),
+			Send: metrics.SendToDB(db, c.MetricsDBTable, c.Org),
+		})
+	}
+
+	wp := gitcollector.NewWorkerPool(jobScheduler, mc)
 	wp.SetWorkers(workers)
 	log.Debugf("number of workers in the pool %d", workers)
 

--- a/discovery/provider.go
+++ b/discovery/provider.go
@@ -146,13 +146,14 @@ func (p *GHProvider) Start() error {
 					continue
 				}
 
-				endpoints, err := getEndpoints(repo)
+				endpoint, err := getEndpoint(repo)
 				if err != nil {
 					continue
 				}
 
 				job = &library.Job{
-					Endpoints: endpoints,
+					Type:      library.JobDownload,
+					Endpoints: []string{endpoint},
 				}
 			}
 
@@ -178,8 +179,8 @@ func (p *GHProvider) Start() error {
 	}
 }
 
-func getEndpoints(r *github.Repository) ([]string, error) {
-	var endpoints []string
+func getEndpoint(r *github.Repository) (string, error) {
+	var endpoint string
 	getURLs := []func() string{
 		r.GetHTMLURL,
 		r.GetGitURL,
@@ -189,15 +190,16 @@ func getEndpoints(r *github.Repository) ([]string, error) {
 	for _, getURL := range getURLs {
 		ep := getURL()
 		if ep != "" {
-			endpoints = append(endpoints, ep)
+			endpoint = ep
+			break
 		}
 	}
 
-	if len(endpoints) < 1 {
-		return nil, ErrEndpointsNotFound.New(r.GetFullName())
+	if endpoint == "" {
+		return "", ErrEndpointsNotFound.New(r.GetFullName())
 	}
 
-	return endpoints, nil
+	return endpoint, nil
 }
 
 // Stop implements the gitcollector.Provider interface

--- a/discovery/provider_test.go
+++ b/discovery/provider_test.go
@@ -64,7 +64,7 @@ func TestGHProvider(t *testing.T) {
 	for job := range consumedJobs {
 		j, ok := job.(*library.Job)
 		req.True(ok)
-		req.Len(j.Endpoints, 3)
+		req.Len(j.Endpoints, 1)
 		for _, ep := range j.Endpoints {
 			req.True(strings.Contains(ep, org))
 		}

--- a/downloader/download.go
+++ b/downloader/download.go
@@ -34,7 +34,10 @@ var (
 // it in a borges.Library.
 func Download(ctx context.Context, job *library.Job) error {
 	logger := job.Logger.New(log.Fields{"job": "download", "id": job.ID})
-	if len(job.Endpoints) == 0 || job.Lib == nil || job.TempFS == nil {
+	if job.Type != library.JobDownload ||
+		len(job.Endpoints) == 0 ||
+		job.Lib == nil ||
+		job.TempFS == nil {
 		err := ErrNotDownloadJob.New()
 		logger.Errorf(err, "wrong job")
 		return err
@@ -63,7 +66,8 @@ func Download(ctx context.Context, job *library.Job) error {
 	}
 
 	if ok {
-		if job.Update {
+		if job.AllowUpdate {
+			job.Type = library.JobUpdate
 			job.LocationID = locID
 			return updater.Update(ctx, job)
 		}

--- a/downloader/download_test.go
+++ b/downloader/download_test.go
@@ -110,6 +110,7 @@ func TestDownload(t *testing.T) {
 		for _, id := range test.repoIDs {
 			job := &library.Job{
 				Lib:       lib,
+				Type:      library.JobDownload,
 				Endpoints: []string{fmt.Sprintf(ep, id)},
 				TempFS:    temp,
 				AuthToken: func(string) string { return "" },

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7
 	github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d // indirect
+	github.com/lib/pq v1.1.1
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lib/pq v1.1.1 h1:sJZmqHoEaY7f+NPP8pgLB/WxulyR3fewgCM2qaSlBb4=
+github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=

--- a/job.go
+++ b/job.go
@@ -12,14 +12,18 @@ type Job interface {
 	Process(context.Context) error
 }
 
-// JobScheduler schedule the Jobs to be processed.
-type JobScheduler interface {
-	// Jobs returns a channel where the Jobs will be scheduled.
-	Jobs() chan Job
-	// Schedule start to schedule Jobs.
-	Schedule()
-	// Finish stop to schedule Jobs.
-	Finish()
+// MetricsCollector represents a component in charge to collect jobs metrics.
+type MetricsCollector interface {
+	// Start starts collecting metrics.
+	Start()
+	// Stop stops collectingMetrincs.
+	Stop()
+	// Success registers metrics about successfully processed Job.
+	Success(Job)
+	// Faile register metrics about a failed processed Job.
+	Fail(Job)
+	// Discover register metrics about a discovered Job.
+	Discover(Job)
 }
 
 var (

--- a/job.go
+++ b/job.go
@@ -17,7 +17,7 @@ type MetricsCollector interface {
 	// Start starts collecting metrics.
 	Start()
 	// Stop stops collectingMetrincs.
-	Stop()
+	Stop(immediate bool)
 	// Success registers metrics about successfully processed Job.
 	Success(Job)
 	// Faile register metrics about a failed processed Job.

--- a/library/job_test.go
+++ b/library/job_test.go
@@ -109,12 +109,15 @@ func testScheduleFn(
 	endpoints []string,
 	queues []chan gitcollector.Job,
 ) []string {
-	wp := gitcollector.NewWorkerPool(gitcollector.NewJobScheduler(
-		sched,
-		&gitcollector.JobSchedulerOpts{
-			NotWaitNewJobs: true,
-		},
-	))
+	wp := gitcollector.NewWorkerPool(
+		gitcollector.NewJobScheduler(
+			sched,
+			&gitcollector.JobSchedulerOpts{
+				NotWaitNewJobs: true,
+			},
+		),
+		nil,
+	)
 
 	wp.SetWorkers(10)
 	wp.Run()

--- a/library/job_test.go
+++ b/library/job_test.go
@@ -123,8 +123,14 @@ func testScheduleFn(
 	wp.Run()
 
 	for _, e := range endpoints {
-		for _, queue := range queues {
+		for i, queue := range queues {
+			var t JobType = JobDownload
+			if i != 0 {
+				t = JobUpdate
+			}
+
 			queue <- &Job{
+				Type:      t,
 				Endpoints: []string{e},
 			}
 		}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,259 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/src-d/gitcollector"
+	"github.com/src-d/gitcollector/library"
+	"gopkg.in/src-d/go-log.v1"
+)
+
+// SendFn is the function a Collector will use to export metrics.
+type SendFn func(context.Context, *Collector, *library.Job) error
+
+// CollectorOpts represenst configuration options for a Collector.
+type CollectorOpts struct {
+	BatchSize int
+	SyncTime  time.Duration
+	Log       log.Logger
+	Send      SendFn
+}
+
+// Collector is an implementation of gitcollector.MetricsCollector
+type Collector struct {
+	logger log.Logger
+	opts   *CollectorOpts
+
+	success              chan gitcollector.Job
+	successDownloadCount uint64
+	successUpdateCount   uint64
+
+	fail      chan gitcollector.Job
+	failCount uint64
+
+	discover      chan gitcollector.Job
+	discoverCount uint64
+
+	wg     sync.WaitGroup
+	cancel chan bool
+}
+
+var _ gitcollector.MetricsCollector = (*Collector)(nil)
+
+const (
+	batchSize   = 10
+	syncTime    = 30 * time.Second
+	waitTimeout = 5 * time.Second
+)
+
+// NewCollector builds a new Collector.
+func NewCollector(opts *CollectorOpts) *Collector {
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = batchSize
+	}
+
+	if opts.SyncTime <= 0 {
+		opts.SyncTime = syncTime
+	}
+
+	if opts.Log == nil {
+		opts.Log = log.New(nil)
+	}
+
+	if opts.Send == nil {
+		opts.Send = func(
+			_ context.Context,
+			_ *Collector,
+			_ *library.Job,
+		) error {
+			return nil
+		}
+	}
+
+	opts.Log = opts.Log.New(log.Fields{"metrics": "library"})
+	capacity := 5 * opts.BatchSize
+	return &Collector{
+		logger:   opts.Log,
+		opts:     opts,
+		success:  make(chan gitcollector.Job, capacity),
+		fail:     make(chan gitcollector.Job, capacity),
+		discover: make(chan gitcollector.Job, capacity),
+		cancel:   make(chan bool),
+	}
+}
+
+const (
+	successKind = iota
+	failKind
+	discoverKind
+)
+
+// Start implements the gitcollector.MetricsCollector interface.
+func (mc *Collector) Start() {
+	mc.wg.Add(1)
+	defer mc.wg.Done()
+
+	var (
+		stop     bool
+		batch    int
+		lastSent = time.Now()
+		job      *library.Job
+	)
+
+	for !(mc.isClosed() || stop) {
+		var (
+			j    gitcollector.Job
+			kind int
+		)
+
+		select {
+		case job, ok := <-mc.success:
+			if !ok {
+				mc.success = nil
+				continue
+			}
+
+			j, kind = job, successKind
+		case job, ok := <-mc.fail:
+			if !ok {
+				mc.fail = nil
+				continue
+			}
+
+			j, kind = job, failKind
+		case job, ok := <-mc.discover:
+			if !ok {
+				mc.discover = nil
+				continue
+			}
+
+			j, kind = job, discoverKind
+		case stop = <-mc.cancel:
+			mc.close()
+			continue
+		case <-time.After(waitTimeout):
+			mc.logger.Debugf("waiting new metrics")
+			continue
+		}
+
+		var ok bool
+		job, ok = j.(*library.Job)
+		if !ok {
+			mc.logger.Warningf("wrong job found: %T", j)
+			continue
+		}
+
+		if err := mc.modifyMetrics(job, kind); err != nil {
+			log.Warningf(err.Error())
+			continue
+		}
+
+		batch++
+		if mc.sendMetric(batch, lastSent) {
+			lastSent = time.Now()
+			if err := mc.opts.Send(
+				context.TODO(),
+				mc,
+				job,
+			); err != nil {
+				mc.logger.Warningf(
+					"couldn't send metrics: %s",
+					err.Error(),
+				)
+
+				continue
+			}
+
+			batch = 0
+		}
+	}
+
+	if batch > 0 && !stop {
+		if err := mc.opts.Send(context.TODO(), mc, job); err != nil {
+			mc.logger.Warningf(
+				"couldn't send metrics: %s",
+				err.Error(),
+			)
+		}
+	}
+
+	mc.logger.Infof(
+		"discover: %d, download: %d, update: %d, fail: %d",
+		mc.discoverCount,
+		mc.successDownloadCount,
+		mc.successUpdateCount,
+		mc.failCount,
+	)
+}
+
+func (mc *Collector) isClosed() bool {
+	return mc.success == nil && mc.fail == nil && mc.discover == nil
+}
+
+func (mc *Collector) close() {
+	close(mc.success)
+	close(mc.fail)
+	close(mc.discover)
+	close(mc.cancel)
+	mc.cancel = nil
+}
+
+func (mc *Collector) modifyMetrics(job *library.Job, kind int) error {
+	switch kind {
+	case successKind:
+		if job.Type == library.JobDownload {
+			mc.successDownloadCount++
+			break
+		}
+
+		for range job.Endpoints {
+			mc.successUpdateCount++
+		}
+	case failKind:
+		for range job.Endpoints {
+			mc.failCount++
+		}
+	case discoverKind:
+		if job.Type == library.JobDownload {
+			mc.discoverCount++
+		}
+	default:
+		return fmt.Errorf("wrong metric type found: %d", kind)
+	}
+
+	return nil
+}
+
+func (mc *Collector) sendMetric(batch int, lastSent time.Time) bool {
+	fullBatch := batch >= mc.opts.BatchSize
+	syncTimeout := time.Since(lastSent) >= mc.opts.SyncTime && batch > 0
+	return fullBatch || syncTimeout
+}
+
+// Stop implements the gitcollector.MetricsCollector interface.
+func (mc *Collector) Stop(immediate bool) {
+	if mc.cancel == nil {
+		return
+	}
+
+	mc.cancel <- immediate
+	mc.wg.Wait()
+}
+
+// Success implements the gitcollector.MetricsCollector interface.
+func (mc *Collector) Success(job gitcollector.Job) {
+	mc.success <- job
+}
+
+// Fail implements the gitcollector.MetricsCollector interface.
+func (mc *Collector) Fail(job gitcollector.Job) {
+	mc.fail <- job
+}
+
+// Discover implements the gitcollector.MetricsCollector interface.
+func (mc *Collector) Discover(job gitcollector.Job) {
+	mc.discover <- job
+}

--- a/metrics/metrics_db.go
+++ b/metrics/metrics_db.go
@@ -1,0 +1,101 @@
+package metrics
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/src-d/gitcollector/library"
+
+	// postgres database driver
+	_ "github.com/lib/pq"
+)
+
+// PrepareDB performs the necessary operations to send metrics to a postgres
+// database.
+func PrepareDB(uri string, table, org string) (*sql.DB, error) {
+	db, err := sql.Open("postgres", uri)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := db.Ping(); err != nil {
+		return nil, err
+	}
+
+	statements := []string{
+		fmt.Sprintf(create, table),
+		fmt.Sprintf(addColumns, table),
+		fmt.Sprintf(insert, table, org),
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	for _, s := range statements {
+		if _, err := tx.Exec(s); err != nil {
+			tx.Rollback()
+			db.Close()
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	return db, nil
+}
+
+const (
+	create = `CREATE TABLE IF NOT EXISTS %s (
+		org VARCHAR(50) NOT NULL,
+		discovered INTEGER NOT NULL,
+		downloaded INTEGER NOT NULL,
+		updated INTEGER NOT NULL,
+		failed INTEGER NOT NULL
+	)`
+
+	insert = `INSERT INTO %[1]s(org, discovered, downloaded, updated, failed)
+	SELECT '%[2]s',0,0,0,0
+	WHERE NOT EXISTS (SELECT * FROM %[1]s)`
+
+	addColumns = `ALTER TABLE %s
+	ADD COLUMN IF NOT EXISTS discovered INTEGER,
+	ADD COLUMN IF NOT EXISTS downloaded INTEGER,
+	ADD COLUMN IF NOT EXISTS updated INTEGER,
+	ADD COLUMN IF NOT EXISTS failed INTEGER`
+
+	update = `UPDATE %s
+	SET discovered = %d,
+	    downloaded = %d,
+	    updated = %d,
+	    failed = %d
+	WHERE org = '%s';`
+)
+
+// SendToDB is a SendFn to persist metrics on a database.
+func SendToDB(db *sql.DB, table, org string) SendFn {
+	return func(
+		_ context.Context,
+		mc *Collector,
+		_ *library.Job,
+	) error {
+		statement := fmt.Sprintf(
+			update,
+			table,
+			mc.discoverCount,
+			mc.successDownloadCount,
+			mc.successUpdateCount,
+			mc.failCount,
+			org,
+		)
+
+		_, err := db.Exec(statement)
+		return err
+	}
+}

--- a/scheduler.go
+++ b/scheduler.go
@@ -107,6 +107,7 @@ func (s *JobScheduler) Schedule() {
 
 			select {
 			case s.jobs <- job:
+				s.metrics.Discover(job)
 			case <-s.cancel:
 				return
 			}

--- a/scheduler.go
+++ b/scheduler.go
@@ -9,15 +9,6 @@ import (
 // ScheduleFn is a function to schedule the next Job.
 type ScheduleFn func(*JobSchedulerOpts) (Job, error)
 
-type jobScheduler struct {
-	jobs     chan Job
-	schedule ScheduleFn
-	cancel   chan struct{}
-	opts     *JobSchedulerOpts
-}
-
-var _ JobScheduler = (*jobScheduler)(nil)
-
 // JobSchedulerOpts are configuration options for a JobScheduler.
 type JobSchedulerOpts struct {
 	Capacity       int
@@ -41,8 +32,20 @@ var (
 	ErrClosedChannel = errors.NewKind("channel is closed")
 )
 
+// JobScheduler schedules the Jobs to be processed.
+type JobScheduler struct {
+	jobs     chan Job
+	schedule ScheduleFn
+	cancel   chan struct{}
+	metrics  MetricsCollector
+	opts     *JobSchedulerOpts
+}
+
 // NewJobScheduler builds a new JobScheduler.
-func NewJobScheduler(schedule ScheduleFn, opts *JobSchedulerOpts) JobScheduler {
+func NewJobScheduler(
+	schedule ScheduleFn,
+	opts *JobSchedulerOpts,
+) *JobScheduler {
 	if opts.Capacity <= 0 {
 		opts.Capacity = schedCapacity
 	}
@@ -55,7 +58,7 @@ func NewJobScheduler(schedule ScheduleFn, opts *JobSchedulerOpts) JobScheduler {
 		opts.NewJobTimeout = newJobTimeout
 	}
 
-	return &jobScheduler{
+	return &JobScheduler{
 		jobs:     make(chan Job, opts.Capacity),
 		schedule: schedule,
 		cancel:   make(chan struct{}),
@@ -63,18 +66,18 @@ func NewJobScheduler(schedule ScheduleFn, opts *JobSchedulerOpts) JobScheduler {
 	}
 }
 
-// Jobs implements the JobScheduler interface.
-func (s *jobScheduler) Jobs() chan Job {
+// Jobs returns the channel where the JobScheduler will schedule the Jobs.
+func (s *JobScheduler) Jobs() chan Job {
 	return s.jobs
 }
 
-// Finish implements the JobScheduler interface.
-func (s *jobScheduler) Finish() {
+// Finish finishes to schedule Jobs.
+func (s *JobScheduler) Finish() {
 	s.cancel <- struct{}{}
 }
 
-// Schedule implements the JobScheduler interface.
-func (s *jobScheduler) Schedule() {
+// Schedule schedules Jobs.
+func (s *JobScheduler) Schedule() {
 	for {
 		select {
 		case <-s.cancel:

--- a/updater/provider.go
+++ b/updater/provider.go
@@ -107,8 +107,8 @@ func (p *UpdatesProvider) update() error {
 
 		iter.ForEach(func(l borges.Location) error {
 			job := &library.Job{
+				Type:       library.JobUpdate,
 				LocationID: l.ID(),
-				Update:     true,
 			}
 
 			select {

--- a/updater/provider_test.go
+++ b/updater/provider_test.go
@@ -51,7 +51,7 @@ func TestUpdatesProvider(t *testing.T) {
 		j, ok := job.(*library.Job)
 		require.True(ok)
 		require.Contains(ids, j.LocationID)
-		require.True(j.Update)
+		require.True(j.Type == library.JobUpdate)
 	}
 }
 

--- a/updater/update.go
+++ b/updater/update.go
@@ -22,7 +22,7 @@ var (
 // in a borges.Library.
 func Update(_ context.Context, job *library.Job) error {
 	logger := job.Logger.New(log.Fields{"job": "update", "id": job.ID})
-	if !job.Update {
+	if job.Type != library.JobUpdate {
 		err := ErrNotUpdateJob.New()
 		logger.Errorf(err, "wrong job")
 		return err
@@ -49,8 +49,15 @@ func Update(_ context.Context, job *library.Job) error {
 		return err
 	}
 
+	repo, err := loc.Get("", borges.RWMode)
+	if err != nil {
+		logger.Errorf(err, "couldn't get repository")
+		return err
+	}
+
 	var remote string
-	if len(job.Endpoints) > 0 {
+	if len(job.Endpoints) == 1 {
+		// job redirected from download
 		ep := job.Endpoints[0]
 
 		logger = logger.New(log.Fields{"url": ep})
@@ -64,12 +71,29 @@ func Update(_ context.Context, job *library.Job) error {
 		remote = id.String()
 	}
 
+	remotes, err := remotesToUpdate(repo, remote)
+	if err != nil {
+		logger.Errorf(err, "couldn't get remotes")
+		return err
+	}
+
+	if len(job.Endpoints) == 0 {
+		// it will update the whole location, add all the endpoints
+		// to be updated to the job
+		var endpoints []string
+		for _, remote := range remotes {
+			endpoints = append(endpoints, remote.Config().URLs[0])
+		}
+
+		job.Endpoints = endpoints
+	}
+
 	logger.Infof("started")
 	start := time.Now()
 	if err := updateRepository(
 		logger,
-		loc,
-		remote,
+		repo,
+		remotes,
 		job.AuthToken,
 	); err != nil {
 		logger.Errorf(err, "failed")
@@ -81,32 +105,35 @@ func Update(_ context.Context, job *library.Job) error {
 	return nil
 }
 
-func updateRepository(
-	logger log.Logger,
-	loc *siva.Location,
-	remote string,
-	authToken library.AuthTokenFn,
-) error {
-	repo, err := loc.Get("", borges.RWMode)
-	if err != nil {
-		return err
-	}
+func remotesToUpdate(repo borges.Repository, remote string) ([]*git.Remote, error) {
+	var (
+		remotes []*git.Remote
+		err     error
+	)
 
-	var remotes []*git.Remote
 	if remote == "" {
 		remotes, err = repo.R().Remotes()
 		if err != nil {
-			return err
+			return nil, err
 		}
 	} else {
 		r, err := repo.R().Remote(remote)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		remotes = append(remotes, r)
 	}
 
+	return remotes, nil
+}
+
+func updateRepository(
+	logger log.Logger,
+	repo borges.Repository,
+	remotes []*git.Remote,
+	authToken library.AuthTokenFn,
+) error {
 	var alreadyUpdated int
 	start := time.Now()
 	for _, remote := range remotes {

--- a/updater/update_test.go
+++ b/updater/update_test.go
@@ -45,12 +45,11 @@ func TestUpdate(t *testing.T) {
 
 	job := &library.Job{
 		ID:         "foo",
-		Endpoints:  []string{},
+		Type:       library.JobUpdate,
 		Lib:        lib1,
 		LocationID: locID,
 		AuthToken:  func(string) string { return "" },
 		Logger:     log.New(nil),
-		Update:     true,
 	}
 
 	// Update all remotes

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -6,25 +6,36 @@ import (
 
 // WorkerPool holds a pool of workers.
 type WorkerPool struct {
-	scheduler JobScheduler
+	scheduler *JobScheduler
+	metrics   MetricsCollector
 	workers   []*Worker
 	resize    chan struct{}
 	wg        sync.WaitGroup
 }
 
 // NewWorkerPool builds a new WorkerPool.
-func NewWorkerPool(scheduler JobScheduler) *WorkerPool {
+func NewWorkerPool(
+	scheduler *JobScheduler,
+	metrics MetricsCollector,
+) *WorkerPool {
 	resize := make(chan struct{}, 1)
 	resize <- struct{}{}
+	if metrics == nil {
+		metrics = &hollowMetricsCollector{}
+	}
+
 	return &WorkerPool{
 		scheduler: scheduler,
+		metrics:   metrics,
 		resize:    resize,
 	}
 }
 
 // Run notify workers to start.
 func (wp *WorkerPool) Run() {
-	go func() { wp.scheduler.Schedule() }()
+	wp.scheduler.metrics = wp.metrics
+	go wp.metrics.Start()
+	go wp.scheduler.Schedule()
 }
 
 // Size returns the current number of workers in the pool.
@@ -57,7 +68,7 @@ func (wp *WorkerPool) SetWorkers(n int) {
 func (wp *WorkerPool) add(n int) {
 	wp.wg.Add(n)
 	for i := 0; i < n; i++ {
-		w := NewWorker(wp.scheduler.Jobs())
+		w := NewWorker(wp.scheduler.Jobs(), wp.metrics)
 		go func() {
 			w.Start()
 			wp.wg.Done()
@@ -95,6 +106,7 @@ func (wp *WorkerPool) Wait() {
 
 	wp.wg.Wait()
 	wp.workers = nil
+	wp.metrics.Stop()
 }
 
 // Close stops all the workers in the pool waiting for the jobs to finish.
@@ -102,6 +114,7 @@ func (wp *WorkerPool) Close() {
 	wp.SetWorkers(0)
 	wp.wg.Wait()
 	wp.scheduler.Finish()
+	wp.metrics.Stop()
 }
 
 // Stop stops all the workers in the pool immediately.
@@ -116,4 +129,15 @@ func (wp *WorkerPool) Stop() {
 	wp.wg.Wait()
 	wp.workers = nil
 	wp.scheduler.Finish()
+	wp.metrics.Stop()
 }
+
+type hollowMetricsCollector struct{}
+
+var _ MetricsCollector = (*hollowMetricsCollector)(nil)
+
+func (mc *hollowMetricsCollector) Start()       {}
+func (mc *hollowMetricsCollector) Stop()        {}
+func (mc *hollowMetricsCollector) Success(Job)  {}
+func (mc *hollowMetricsCollector) Fail(Job)     {}
+func (mc *hollowMetricsCollector) Discover(Job) {}

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -106,7 +106,7 @@ func (wp *WorkerPool) Wait() {
 
 	wp.wg.Wait()
 	wp.workers = nil
-	wp.metrics.Stop()
+	wp.metrics.Stop(false)
 }
 
 // Close stops all the workers in the pool waiting for the jobs to finish.
@@ -114,7 +114,7 @@ func (wp *WorkerPool) Close() {
 	wp.SetWorkers(0)
 	wp.wg.Wait()
 	wp.scheduler.Finish()
-	wp.metrics.Stop()
+	wp.metrics.Stop(false)
 }
 
 // Stop stops all the workers in the pool immediately.
@@ -129,7 +129,7 @@ func (wp *WorkerPool) Stop() {
 	wp.wg.Wait()
 	wp.workers = nil
 	wp.scheduler.Finish()
-	wp.metrics.Stop()
+	wp.metrics.Stop(true)
 }
 
 type hollowMetricsCollector struct{}
@@ -137,7 +137,7 @@ type hollowMetricsCollector struct{}
 var _ MetricsCollector = (*hollowMetricsCollector)(nil)
 
 func (mc *hollowMetricsCollector) Start()       {}
-func (mc *hollowMetricsCollector) Stop()        {}
+func (mc *hollowMetricsCollector) Stop(bool)    {}
 func (mc *hollowMetricsCollector) Success(Job)  {}
 func (mc *hollowMetricsCollector) Fail(Job)     {}
 func (mc *hollowMetricsCollector) Discover(Job) {}


### PR DESCRIPTION
Closes #25 

### How it works

There are two new configuration ENV variables for the cli:

- `GITCOLLECTOR_METRICS_DB_URI`, it must be a postgres uri connection `postgresql://[user[:password]@][netloc][:port][,...][/dbname][?param1=value1&...])`
- `GITCOLLECTOR_METRICS_DB_TABLE`, name of the table to add the metrics, by default `gitcollector_metrics`

Internal Steps to setup the db:

- If there's no uri, it will work without exporting metrics.
- It will try to create the table if not exists
- it will try to insert a row with the organization if not exists
- If the table exists, it will try to add the columns (`org`, `discovered`, `downloaded`, `updated`, `failed`) to the table.

Updating metrics:

it will update periodically the record of the organization while gitcollector is working.

```
testing=# select * from gitcollector_metrics;
  org   | discovered | downloaded | updated | failed 
--------+------------+------------+---------+--------
 bblfsh |         0 |         0 |       0 |      0
(1 row)

testing=# select * from gitcollector_metrics;
  org   | discovered | downloaded | updated | failed 
--------+------------+------------+---------+--------
 bblfsh |         30 |         8 |       0 |      0
(1 row)

testing=# select * from gitcollector_metrics;
  org   | discovered | downloaded | updated | failed 
--------+------------+------------+---------+--------
 bblfsh |         32 |         18 |       0 |      0
(1 row)

testing=# select * from gitcollector_metrics;
  org   | discovered | downloaded | updated | failed 
--------+------------+------------+---------+--------
 bblfsh |         32 |         28 |       0 |      0
(1 row)

testing=# select * from gitcollector_metrics;
  org   | discovered | downloaded | updated | failed 
--------+------------+------------+---------+--------
 bblfsh |         32 |         32 |       0 |      0
(1 row)

```

