### PR TITLE
*: code refactoring

### DIFF
--- a/library/job_test.go
+++ b/library/job_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 
 	"github.com/src-d/gitcollector"
-	"gopkg.in/src-d/go-log.v1"
-
 	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-log.v1"
 )
 
 func TestJobScheduleFn(t *testing.T) {
@@ -105,18 +104,15 @@ func TestUpdateJobScheduleFn(t *testing.T) {
 }
 
 func testScheduleFn(
-	sched gitcollector.ScheduleFn,
+	sched gitcollector.JobScheduleFn,
 	endpoints []string,
 	queues []chan gitcollector.Job,
 ) []string {
 	wp := gitcollector.NewWorkerPool(
-		gitcollector.NewJobScheduler(
-			sched,
-			&gitcollector.JobSchedulerOpts{
-				NotWaitNewJobs: true,
-			},
-		),
-		nil,
+		sched,
+		&gitcollector.WorkerPoolOpts{
+			NotWaitNewJobs: true,
+		},
 	)
 
 	wp.SetWorkers(10)

--- a/worker.go
+++ b/worker.go
@@ -6,8 +6,7 @@ import (
 	"gopkg.in/src-d/go-errors.v1"
 )
 
-// Worker is in charge of process gitcollector.Jobs.
-type Worker struct {
+type worker struct {
 	id      string
 	jobs    chan Job
 	cancel  chan bool
@@ -15,9 +14,8 @@ type Worker struct {
 	metrics MetricsCollector
 }
 
-// NewWorker builds a new Worker.
-func NewWorker(jobs chan Job, metrics MetricsCollector) *Worker {
-	return &Worker{
+func newWorker(jobs chan Job, metrics MetricsCollector) *worker {
+	return &worker{
 		jobs:    jobs,
 		cancel:  make(chan bool),
 		metrics: metrics,
@@ -29,8 +27,8 @@ var (
 	errWorkerStopped = errors.NewKind("worker was stopped")
 )
 
-// Start starts the Worker. It shouldn't be restarted after a call to Stop.
-func (w *Worker) Start() {
+func (w *worker) start() {
+	// It shouldn't be restarted after a call to stop.
 	if w.stopped {
 		return
 	}
@@ -48,7 +46,7 @@ func (w *Worker) Start() {
 	}
 }
 
-func (w *Worker) consumeJob(ctx context.Context) error {
+func (w *worker) consumeJob(ctx context.Context) error {
 	select {
 	case <-w.cancel:
 		return errWorkerStopped.New()
@@ -81,8 +79,7 @@ func (w *Worker) consumeJob(ctx context.Context) error {
 	}
 }
 
-// Stop stops the Worker.
-func (w *Worker) Stop(immediate bool) {
+func (w *worker) stop(immediate bool) {
 	if w.stopped {
 		return
 	}


### PR DESCRIPTION
also Closes #18 

This PR makes several changes:

- It makes worker and jobScheduler types privates, they are concrete types that a WorkerPool
uses (it relies in their implementation to correctly work) and can not be switched to other types, so they aren't worthy to be exposed. The API become shorter and simpler.

- The worthy configuration part `ScheduleFn` no is `JobScheduleFn` and it's given directly to the WorkerPool constructor:

```go
// before
type ScheduleFn func(*JobSchedulerOpts) (Job, error)

// after
type JobScheduleFn func(context.Context) (Job, error)

```
