### PR TITLE
Lower the level of downloader when repo already exists

### DIFF
--- a/downloader/download.go
+++ b/downloader/download.go
@@ -69,7 +69,7 @@ func Download(ctx context.Context, job *library.Job) error {
 		}
 
 		err := ErrRepoAlreadyExists.New(repoID)
-		logger.Warningf(err.Error())
+		logger.Infof(err.Error())
 		return err
 	}
 


### PR DESCRIPTION
It was logged as `warning`, but since it does not seem to be
a potentially problem, we can log it as `info`
