### PR TITLE
add regression config

### DIFF
--- a/_testdata/regression.yml
+++ b/_testdata/regression.yml
@@ -1,0 +1,3 @@
+# TODO(@lwsanty): change to repos from infra #1130
+# regression config represents the array of lists of github organizations
+- bblfsh,git-fixtures


### PR DESCRIPTION
regression config represents the array of lists of github organizations, soon our tests organizations should be added

Signed-off-by: lwsanty <lwsanty@gmail.com>