### PR TITLE
add tests with race detector + races fixes

### DIFF
--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -33,3 +33,11 @@ jobs:
         bash <(curl -s https://codecov.io/bash) -f coverage.txt -cF $os,$go
       env:
         CODECOV_TOKEN: be731f61-6ca9-42b0-8f1a-59f4a0b28c0d
+
+    - name: Test races
+      run: |
+        make test-race
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ CI_REPOSITORY ?= https://github.com/src-d/ci.git
 CI_BRANCH ?= v1
 CI_PATH ?= .ci
 MAKEFILE := $(CI_PATH)/Makefile.main
+TEST_RACE ?= true
 $(MAKEFILE):
 	git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);
 -include $(MAKEFILE)

--- a/downloader/download.go
+++ b/downloader/download.go
@@ -31,7 +31,7 @@ var (
 func Download(ctx context.Context, job *library.Job) error {
 	logger := job.Logger.New(log.Fields{"job": "download", "id": job.ID})
 	if job.Type != library.JobDownload ||
-		len(job.Endpoints) == 0 ||
+		len(job.Endpoints()) == 0 ||
 		job.Lib == nil ||
 		job.TempFS == nil {
 		err := ErrNotDownloadJob.New()
@@ -46,7 +46,7 @@ func Download(ctx context.Context, job *library.Job) error {
 		return err
 	}
 
-	endpoint := job.Endpoints[0]
+	endpoint := job.Endpoints()[0]
 	logger = logger.New(log.Fields{"url": endpoint})
 
 	repoID, err := library.NewRepositoryID(endpoint)
@@ -113,8 +113,7 @@ func libHas(
 	select {
 	case <-done:
 	case <-ctx.Done():
-		ok = false
-		err = ctx.Err()
+		return false, "", ctx.Err()
 	}
 
 	return ok, locID, err

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/src-d/envconfig v1.0.0 // indirect
 	github.com/src-d/go-borges v0.0.0-20190704083038-44867e8f2a2a
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.4.0
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect
@@ -41,5 +41,6 @@ require (
 	gopkg.in/src-d/go-errors.v1 v1.0.0
 	gopkg.in/src-d/go-git.v4 v4.12.0
 	gopkg.in/src-d/go-log.v1 v1.0.2
+	gopkg.in/yaml.v2 v2.2.4 // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
 github.com/xanzy/ssh-agent v0.2.0 h1:Adglfbi5p9Z0BmK2oKU9nTG+zKfniSfnaMYB+ULd+Ro=
@@ -214,5 +216,7 @@ gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRN
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/library/job_test.go
+++ b/library/job_test.go
@@ -22,7 +22,7 @@ func TestJobScheduleFn(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 
-			got = append(got, j.Endpoints[0])
+			got = append(got, j.Endpoints()[0])
 			return nil
 		}
 	)
@@ -56,7 +56,7 @@ func TestDownloadJobScheduleFn(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 
-			got = append(got, j.Endpoints[0])
+			got = append(got, j.Endpoints()[0])
 			return nil
 		}
 	)
@@ -89,7 +89,7 @@ func TestUpdateJobScheduleFn(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 
-			got = append(got, j.Endpoints[0])
+			got = append(got, j.Endpoints()[0])
 			return nil
 		}
 	)
@@ -127,7 +127,7 @@ func testScheduleFn(
 
 			queue <- &Job{
 				Type:      t,
-				Endpoints: []string{e},
+				endpoints: []string{e},
 			}
 		}
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -225,11 +225,11 @@ func (c *Collector) modifyMetrics(job *library.Job, kind int) error {
 			break
 		}
 
-		for range job.Endpoints {
+		for range job.Endpoints() {
 			c.successUpdateCount++
 		}
 	case failKind:
-		for range job.Endpoints {
+		for range job.Endpoints() {
 			c.failCount++
 		}
 	case discoverKind:
@@ -351,16 +351,16 @@ func (c *CollectorByOrg) Discover(job gitcollector.Job) {
 func triageJob(job gitcollector.Job) map[string]*library.Job {
 	organizations := map[string]*library.Job{}
 	lj, _ := job.(*library.Job)
-	for _, ep := range lj.Endpoints {
+	for _, ep := range lj.Endpoints() {
 		org := library.GetOrgFromEndpoint(ep)
 		j, ok := organizations[org]
 		if !ok {
 			j = &(*lj)
-			j.Endpoints = []string{}
+			j.SetEndpoints([]string{})
 			organizations[org] = j
 		}
 
-		j.Endpoints = append(j.Endpoints, ep)
+		j.SetEndpoints(append(j.Endpoints(), ep))
 	}
 
 	return organizations

--- a/provider/github.go
+++ b/provider/github.go
@@ -42,9 +42,9 @@ func AdvertiseGHRepositoriesOnJobQueue(
 			}
 
 			job := &library.Job{
-				Type:      library.JobDownload,
-				Endpoints: []string{endpoint},
+				Type: library.JobDownload,
 			}
+			job.SetEndpoints([]string{endpoint})
 
 			select {
 			case queue <- job:

--- a/provider/github_test.go
+++ b/provider/github_test.go
@@ -66,7 +66,7 @@ func TestGitHub(t *testing.T) {
 		job, ok := j.(*library.Job)
 		req.True(ok)
 		req.True(job.Type == library.JobDownload)
-		req.Len(job.Endpoints, 1)
-		req.True(strings.Contains(job.Endpoints[0], org))
+		req.Len(job.Endpoints(), 1)
+		req.True(strings.Contains(job.Endpoints()[0], org))
 	}
 }

--- a/updater/update.go
+++ b/updater/update.go
@@ -56,9 +56,9 @@ func Update(ctx context.Context, job *library.Job) error {
 	}
 
 	var remote string
-	if len(job.Endpoints) == 1 {
+	if len(job.Endpoints()) == 1 {
 		// job redirected from download
-		ep := job.Endpoints[0]
+		ep := job.Endpoints()[0]
 
 		logger = logger.New(log.Fields{"url": ep})
 
@@ -77,7 +77,7 @@ func Update(ctx context.Context, job *library.Job) error {
 		return err
 	}
 
-	if len(job.Endpoints) == 0 {
+	if len(job.Endpoints()) == 0 {
 		// it will update the whole location, add all the endpoints
 		// to be updated to the job
 		var endpoints []string
@@ -85,7 +85,7 @@ func Update(ctx context.Context, job *library.Job) error {
 			endpoints = append(endpoints, remote.Config().URLs[0])
 		}
 
-		job.Endpoints = endpoints
+		job.SetEndpoints(endpoints)
 	}
 
 	logger.Infof("started")

--- a/updater/update_test.go
+++ b/updater/update_test.go
@@ -75,7 +75,7 @@ func TestUpdate(t *testing.T) {
 	req.True(os.IsNotExist(err))
 
 	job.Lib = lib2
-	job.Endpoints = []string{endpoints[1]}
+	job.SetEndpoints([]string{endpoints[1]})
 
 	// Update just one remote
 	req.NoError(Update(context.TODO(), job))


### PR DESCRIPTION
1) added tests with race detector to CI
2) fixed race in tests(it was modifying the job while it was processed, @jfontan should we probably handle this case somehow?):
```go
==================
WARNING: DATA RACE
Read at 0x00c00f9960a0 by goroutine 33:
  github.com/src-d/gitcollector/metrics.(*Collector).modifyMetrics()
      /home/lwsanty/goproj/lwsanty/gitcollector/metrics/metrics.go:223 +0x22a
  github.com/src-d/gitcollector/metrics.(*Collector).Start()
      /home/lwsanty/goproj/lwsanty/gitcollector/metrics/metrics.go:154 +0x5b1

Previous write at 0x00c00f9960a0 by goroutine 32:
  github.com/src-d/gitcollector/metrics.testCloseDelayCollector()
      /home/lwsanty/goproj/lwsanty/gitcollector/metrics/metrics_test.go:213 +0x389
  github.com/src-d/gitcollector/metrics.TestClosesWithDelay.func1()
      /home/lwsanty/goproj/lwsanty/gitcollector/metrics/metrics_test.go:184 +0x7e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 33 (running) created at:
  github.com/src-d/gitcollector/metrics.testCloseDelayCollector()
      /home/lwsanty/goproj/lwsanty/gitcollector/metrics/metrics_test.go:203 +0x1d1
  github.com/src-d/gitcollector/metrics.TestClosesWithDelay.func1()
      /home/lwsanty/goproj/lwsanty/gitcollector/metrics/metrics_test.go:184 +0x7e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 32 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  github.com/src-d/gitcollector/metrics.TestClosesWithDelay()
      /home/lwsanty/goproj/lwsanty/gitcollector/metrics/metrics_test.go:183 +0x184
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
```
3) fixed race in `Download`:
```go
==================
WARNING: DATA RACE
Write at 0x00c0002b8110 by goroutine 25:
  github.com/src-d/gitcollector/downloader.libHas.func1()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/download.go:109 +0xfa

Previous write at 0x00c0002b8110 by goroutine 24:
  github.com/src-d/gitcollector/downloader.libHas()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/download.go:117 +0x3bc
  github.com/src-d/gitcollector/downloader.Download()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/download.go:58 +0x554
  github.com/src-d/gitcollector/downloader.testContextCancelledFail()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/download_test.go:239 +0x470
  github.com/src-d/gitcollector/downloader.TestAll.func1()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/download_test.go:138 +0x5b
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 25 (running) created at:
  github.com/src-d/gitcollector/downloader.libHas()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/download.go:108 +0x1ae
  github.com/src-d/gitcollector/downloader.Download()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/download.go:58 +0x554
  github.com/src-d/gitcollector/downloader.testContextCancelledFail()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/download_test.go:239 +0x470
  github.com/src-d/gitcollector/downloader.TestAll.func1()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/download_test.go:138 +0x5b
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 24 (finished) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  github.com/src-d/gitcollector/downloader.TestAll()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/download_test.go:137 +0x315
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
```
4) fixed race in `Download`
```go
==================
WARNING: DATA RACE
Read at 0x00c0001f4148 by goroutine 85:
  github.com/src-d/gitcollector/downloader.Download()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/download.go:34 +0xd91
  github.com/src-d/gitcollector/library.(*Job).Process()
      /home/lwsanty/goproj/lwsanty/gitcollector/library/job.go:57 +0x87
  github.com/src-d/gitcollector.(*worker).consumeJob.func1()
      /home/lwsanty/goproj/lwsanty/gitcollector/worker.go:61 +0x93

Previous write at 0x00c0001f4148 by goroutine 72:
  github.com/src-d/gitcollector/metrics.triageJob()
      /home/lwsanty/goproj/lwsanty/gitcollector/metrics/metrics.go:359 +0x30e
  github.com/src-d/gitcollector/metrics.(*CollectorByOrg).Discover()
      /home/lwsanty/goproj/lwsanty/gitcollector/metrics/metrics.go:340 +0x5d
  github.com/src-d/gitcollector.(*jobScheduler).Schedule()
      /home/lwsanty/goproj/lwsanty/gitcollector/scheduler.go:113 +0x6ba

Goroutine 85 (running) created at:
  github.com/src-d/gitcollector.(*worker).consumeJob()
      /home/lwsanty/goproj/lwsanty/gitcollector/worker.go:59 +0x206
  github.com/src-d/gitcollector.(*worker).start()
      /home/lwsanty/goproj/lwsanty/gitcollector/worker.go:39 +0xf5
  github.com/src-d/gitcollector.(*WorkerPool).add.func1()
      /home/lwsanty/goproj/lwsanty/gitcollector/worker_pool.go:81 +0x38

Goroutine 72 (running) created at:
  github.com/src-d/gitcollector.(*WorkerPool).Run()
      /home/lwsanty/goproj/lwsanty/gitcollector/worker_pool.go:46 +0xbb
  github.com/src-d/gitcollector/cmd/gitcollector/subcmd.(*DownloadCmd).Execute()
      /home/lwsanty/goproj/lwsanty/gitcollector/cmd/gitcollector/subcmd/download.go:167 +0x12fb
  github.com/src-d/gitcollector/integration.testPostgresSendMetricsSuccess()
      /home/lwsanty/goproj/lwsanty/gitcollector/integration/helper.go:72 +0x159
  github.com/src-d/gitcollector/integration.TestPostgres.func1()
      /home/lwsanty/goproj/lwsanty/gitcollector/integration/postgres_test.go:66 +0x9f
  testing.tRunner()
      /opt/hostedtoolcache/go/1.13.3/x64/src/testing/testing.go:909 +0x199
==================
```
+ various other races

Signed-off-by: lwsanty <lwsanty@gmail.com>